### PR TITLE
Filter out NA responses

### DIFF
--- a/R/mod-review-section.R
+++ b/R/mod-review-section.R
@@ -104,7 +104,7 @@ mod_review_section_server <- function(input, output, session, synapse, syn,
   to_show <- reactive({
     dplyr::filter(
       sub_data_tidier,
-      submission == submission() & section == section()
+      submission == submission() & section == section() & !is.na(sub_data_tidier$response)
     )
   })
 


### PR DESCRIPTION
Don't show rows for which the response is NA. Currently, the section will show rows for variables that other submissions have input for, but the current submission does not have input for it.