### PR TITLE
Add internal/external comments

### DIFF
--- a/R/app-server.R
+++ b/R/app-server.R
@@ -32,7 +32,8 @@ app_server <- function(input, output, session) {
       "panel_section",
       synapse = synapse,
       syn = syn,
-      reviews_table = "syn21314955"
+      reviews_table = "syn21314955",
+      submissions_table = "syn21447678"
     )
   })
 }

--- a/man/mod_panel_section.Rd
+++ b/man/mod_panel_section.Rd
@@ -7,7 +7,15 @@
 \usage{
 mod_panel_section_ui(id)
 
-mod_panel_section_server(input, output, session, synapse, syn, reviews_table)
+mod_panel_section_server(
+  input,
+  output,
+  session,
+  synapse,
+  syn,
+  reviews_table,
+  submissions_table
+)
 }
 \arguments{
 \item{id}{shiny id}
@@ -24,6 +32,9 @@ mod_panel_section_server(input, output, session, synapse, syn, reviews_table)
 \item{syn}{Synapse client object (e.g. output of `synapse$Synapse()`)}
 
 \item{reviews_table}{Synapse table that stores the scores and comments}
+
+\item{submissions_table}{Synapse table that stores the 
+overall submission scores and comments}
 }
 \description{
 View summarized scores for a submission


### PR DESCRIPTION
Fixes #8.

Adds ability to submit internal and external comments, as well as an overall score, on full submission. This is a feature of the panel tab. The submission comments and score are saved to a submission-scores Synapse table.