### PR TITLE
Use updated master dccvalidator branch

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Encoding: UTF-8
 LazyData: true
 Depends: R (>= 3.4.0)
 Imports:
-    dccvalidator,
+    dccvalidator (>=0.0.0.9009),
     dplyr,
     glue,
     golem,
@@ -31,7 +31,7 @@ Imports:
     shiny,
     synapseforms
 Remotes:
-    Sage-Bionetworks/dccvalidator@reticulate,
+    Sage-Bionetworks/dccvalidator,
     Sage-Bionetworks/synapseforms
 RoxygenNote: 7.0.2
 Suggests: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Encoding: UTF-8
 LazyData: true
 Depends: R (>= 3.4.0)
 Imports:
-    dccvalidator (>=0.0.0.9009),
+    dccvalidator (>= 0.0.0.9009),
     dplyr,
     glue,
     golem,

--- a/renv.lock
+++ b/renv.lock
@@ -185,14 +185,13 @@
       "Package": "dccvalidator",
       "Version": "0.0.0.9009",
       "Source": "GitHub",
-      "Remotes": "daattali/shinyjs, hadley/emo",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
-      "RemoteRepo": "dccvalidator",
       "RemoteUsername": "Sage-Bionetworks",
-      "RemoteRef": "reticulate",
-      "RemoteSha": "468bd10215910bd121a86923a97b4bb1d6f9b608",
-      "Hash": "9c7943cac991403a14ed433a93692af3"
+      "RemoteRepo": "dccvalidator",
+      "RemoteRef": "master",
+      "RemoteSha": "26ba9fc788065de45537c699c44b782041f39ee5",
+      "Hash": "c7c67bba034dbdbc54737812b35b93fa"
     },
     "desc": {
       "Package": "desc",

--- a/renv.lock
+++ b/renv.lock
@@ -186,12 +186,12 @@
       "Version": "0.0.0.9009",
       "Source": "GitHub",
       "RemoteType": "github",
-      "RemoteHost": "api.github.com",
       "RemoteUsername": "Sage-Bionetworks",
       "RemoteRepo": "dccvalidator",
       "RemoteRef": "master",
-      "RemoteSha": "26ba9fc788065de45537c699c44b782041f39ee5",
-      "Hash": "c7c67bba034dbdbc54737812b35b93fa"
+      "RemoteSha": "f8668d8972828fa26c4631fc0caed1116f77077f",
+      "RemoteHost": "api.github.com",
+      "Hash": "6fabbeb33b589977e6fb0786985c6f3d"
     },
     "desc": {
       "Package": "desc",
@@ -769,9 +769,9 @@
       "RemoteUsername": "Sage-Bionetworks",
       "RemoteRepo": "synapseforms",
       "RemoteRef": "master",
-      "RemoteSha": "e42dcac77ecfbb1f1326550d416b794fd5416b56",
+      "RemoteSha": "66346282918c651e24eb28aa005672858881fef1",
       "RemoteHost": "api.github.com",
-      "Hash": "6f4785146a0d258041ec8d1fbde474a1"
+      "Hash": "373713d73ece7689062ca13a92838590"
     },
     "sys": {
       "Package": "sys",

--- a/renv.lock
+++ b/renv.lock
@@ -186,12 +186,12 @@
       "Version": "0.0.0.9009",
       "Source": "GitHub",
       "RemoteType": "github",
+      "RemoteHost": "api.github.com",
       "RemoteUsername": "Sage-Bionetworks",
       "RemoteRepo": "dccvalidator",
       "RemoteRef": "master",
-      "RemoteSha": "f8668d8972828fa26c4631fc0caed1116f77077f",
-      "RemoteHost": "api.github.com",
-      "Hash": "6fabbeb33b589977e6fb0786985c6f3d"
+      "RemoteSha": "b561f0dd639cd30ec0d84435e11d58ee6e1cf091",
+      "Hash": "2eb5f27eb1878d22ed3a494221f92f53"
     },
     "desc": {
       "Package": "desc",


### PR DESCRIPTION
The reticulate branch has been merged, so we can use the master branch now, and depend on version >=0.0.0.9009