### PR TITLE
Update synapseforms version and needed changes

### DIFF
--- a/R/mod-review-section.R
+++ b/R/mod-review-section.R
@@ -84,7 +84,7 @@ mod_review_section_server <- function(input, output, session, synapse, syn,
     "submission",
     choices = c(
       "",
-      synapseforms::get_submission_names(sub_data)
+      synapseforms::get_submission_ids(sub_data)
     )
   )
 
@@ -108,7 +108,7 @@ mod_review_section_server <- function(input, output, session, synapse, syn,
   to_show <- reactive({
     dplyr::filter(
       sub_data,
-      submission == submission() & section == section() &!is.na(sub_data$response)
+      form_data_id == submission() & section == section() &!is.na(sub_data$response)
     )
   })
 

--- a/renv.lock
+++ b/renv.lock
@@ -769,9 +769,9 @@
       "RemoteUsername": "Sage-Bionetworks",
       "RemoteRepo": "synapseforms",
       "RemoteRef": "master",
-      "RemoteSha": "66346282918c651e24eb28aa005672858881fef1",
+      "RemoteSha": "b9c5fbfb93a3d26f00895629d04d0e89b9ebb81b",
       "RemoteHost": "api.github.com",
-      "Hash": "373713d73ece7689062ca13a92838590"
+      "Hash": "76ce57326673d35816c8e15491adb27d"
     },
     "sys": {
       "Package": "sys",


### PR DESCRIPTION
Update the lockfile with the latest synapseforms. The latest version of synapseforms changes the column "submission" to "form_data_id" and `get_submission_names()` to `get_submission_ids()`. Make updates to use the correct names/functions. This will make creating user friendly submission names easier.