### PR TITLE
Fix issues with new synapseforms version and updated tables

### DIFF
--- a/R/mod-panel-section.R
+++ b/R/mod-panel-section.R
@@ -104,15 +104,17 @@ mod_panel_section_server <- function(input, output, session, synapse, syn,
       if (nchar(input$internal_comments) > 500 || nchar(input$external_comments) > 500) {
         stop("Please limit comments to 500 characters")
       }
+      form_data_id <- reviews$formDataId[which(reviews$submission == input$submission)[1]]
       result <- readr::read_csv(
         syn$tableQuery(
           glue::glue(
-            "SELECT * FROM {submissions_table} WHERE (scorer = {syn$getUserProfile()$ownerId} AND submission = '{input$submission}')"
+            "SELECT * FROM {submissions_table} WHERE (scorer = {syn$getUserProfile()$ownerId} AND formDataId = {form_data_id})"
           )
         )$filepath
       )
       if (nrow(result) == 0 ) {
         new_row <- data.frame(
+          formDataId = form_data_id,
           submission = input$submission,
           scorer = syn$getUserProfile()$ownerId,
           overall_score = input$overall_score,

--- a/R/mod-review-section.R
+++ b/R/mod-review-section.R
@@ -122,12 +122,13 @@ mod_review_section_server <- function(input, output, session, synapse, syn,
       result <- readr::read_csv(
         syn$tableQuery(
           glue::glue(
-            "SELECT * FROM {reviews_table} WHERE (scorer = {syn$getUserProfile()$ownerId} AND submission = '{input$submission}' AND section = '{input$section}')"
+            "SELECT * FROM {reviews_table} WHERE (scorer = {syn$getUserProfile()$ownerId} AND formDataId = '{input$submission}' AND section = '{input$section}')"
           )
         )$filepath
       )
       if (nrow(result) == 0 ) {
         new_row <- data.frame(
+          formDataId = input$submission,
           submission = input$submission,
           section = input$section,
           scorer = syn$getUserProfile()$ownerId,


### PR DESCRIPTION
Updated the submission and section scoring tables to hold the formDataId (snake-case to be consistent with the rest of Synapse). Changed stopadforms to store this value and to lookup the submission by it. Since formDataId is unique, this reduces errors that could result in duplicate submission names (although we still need to not have duplicate submission names...).

Since the latest version of synapseforms removes the submission column and uses form_data_id, this changes the submission name uploaded to the Synapse table. If a person has commented on the same submission/section before the update and then tried to comment again after the update, the query would not get the previous comment. Instead, a second comment on a "different" submission would be added. This update makes stopadforms query for the formDataId instead of submission name.