### PR TITLE
Don't paginate tables showing sections

### DIFF
--- a/R/mod-panel-section.R
+++ b/R/mod-panel-section.R
@@ -172,6 +172,7 @@ show_review_table <- function(input, output, reviews, submission) {
       to_show(),
       groupBy = "section",
       searchable = TRUE,
+      pagination = FALSE,
       columns = list(
         section = reactable::colDef(name = "Section"),
         score = reactable::colDef(name = "Score", aggregate = "mean"),

--- a/R/mod-review-section.R
+++ b/R/mod-review-section.R
@@ -132,7 +132,7 @@ mod_review_section_server <- function(input, output, session, synapse, syn,
   })
 
   output$data_section_subset <- reactable::renderReactable({
-    reactable::reactable(to_show())
+    reactable::reactable(to_show(), pagination = FALSE)
   })
 
   ## Save new row to table


### PR DESCRIPTION
Stacey asked that we not paginate the tables that show sections of people's responses, as it's easy to overlook some data if it's paginated.