### PR TITLE
Ordinal section scoring

### DIFF
--- a/R/mod-review-section.R
+++ b/R/mod-review-section.R
@@ -56,10 +56,16 @@ mod_review_section_ui <- function(id) {
       column(
         4,
         offset = 5,
-        numericInput(
+        selectInput(
           inputId = ns("section_score"),
           label = "Score",
-          value = 1
+          choices = c(
+            "None" = 0,
+            "Poor" = 0.1,
+            "Fair" = 0.25,
+            "Good" = 0.85,
+            "Excellent" = 1
+          )
         ),
         textAreaInput(
           inputId = ns("section_comments"),


### PR DESCRIPTION
Fixes #40.

The only change currently is to display "None, Poor, Fair, Good, Excellent" on the section scoring and for these to have specific values as defined in #40. The value that is saved to the section-scoring table in Synapse is the defined numeric value (ie 0, 0.1, 0.25,...).

Since the table structures did not change, the panel section shows the numeric values, not ordinal values, for the user scores. This works well for averaging the values and keeping the table simple, but also looks a little odd since a user would have scored something as "Poor", not 0.1. That said, these are values the clients chose themselves. Ultimately, I'm not sure which is better: let the panel table show the numeric values or change the panel table to show both the ordinal and numeric values.