### PR TITLE
Improve error message if user is not certified

### DIFF
--- a/R/app-server.R
+++ b/R/app-server.R
@@ -58,6 +58,7 @@ app_server <- function(input, output, session) {
         "review_section",
         synapse = synapse,
         syn = syn,
+        user = user,
         reviews_table = "syn21314955",
         lookup_table = lookup_table
       )
@@ -67,6 +68,7 @@ app_server <- function(input, output, session) {
         "panel_section",
         synapse = synapse,
         syn = syn,
+        user = user,
         reviews_table = "syn21314955",
         submissions_table = "syn21447678"
       )

--- a/R/mod-panel-section.R
+++ b/R/mod-panel-section.R
@@ -72,7 +72,7 @@ mod_panel_section_ui <- function(id) {
 
 #' @rdname mod_panel_section
 #' @keywords internal
-mod_panel_section_server <- function(input, output, session, synapse, syn,
+mod_panel_section_server <- function(input, output, session, synapse, syn, user,
                                      reviews_table, submissions_table) {
   ## Load reviews
   reviews <- pull_reviews_table(syn, reviews_table)
@@ -106,10 +106,17 @@ mod_panel_section_server <- function(input, output, session, synapse, syn,
       show_review_table(input, output, reviews, submission_id)
     })
   })
+  certified <- dccvalidator::check_certified_user(user$ownerId, syn = syn)
 
   ## Save new row to table
   observeEvent(input$submit, {
     dccvalidator::with_busy_indicator_server("submit", {
+      validate(
+        need(
+          inherits(certified, "check_pass"),
+          HTML("You must be a Synapse Certified User to save reviews. <a href=\"https://docs.synapse.org/articles/accounts_certified_users_and_profile_validation.html\">Learn more</a>")
+        )
+      )
       if (nchar(input$internal_comments) > 500 || nchar(input$external_comments) > 500) { # nolint
         stop("Please limit comments to 500 characters")
       }

--- a/R/mod-review-section.R
+++ b/R/mod-review-section.R
@@ -85,7 +85,7 @@ mod_review_section_ui <- function(id) {
 #' @rdname mod_review_section
 #' @keywords internal
 mod_review_section_server <- function(input, output, session, synapse, syn,
-                                      reviews_table, lookup_table) {
+                                      user, reviews_table, lookup_table) {
   # Get submission data in nice table for viewing
   sub_data <- get_submissions(
     syn,
@@ -148,10 +148,17 @@ mod_review_section_server <- function(input, output, session, synapse, syn,
       )
     )
   })
+  certified <- dccvalidator::check_certified_user(user$ownerId, syn = syn)
 
   ## Save new row to table
   observeEvent(input$submit, {
     dccvalidator::with_busy_indicator_server("submit", {
+      validate(
+        need(
+          inherits(certified, "check_pass"),
+          HTML("You must be a Synapse Certified User to save reviews. <a href=\"https://docs.synapse.org/articles/accounts_certified_users_and_profile_validation.html\">Learn more</a>")
+        )
+      )
       if (input$submission == "" || input$section == "") {
         stop("Please select a submission and section")
       }


### PR DESCRIPTION
Fixes #50. The "Learn more" link takes you to here: https://docs.synapse.org/articles/accounts_certified_users_and_profile_validation.html

![Screen Shot 2020-02-17 at 1 28 57 PM](https://user-images.githubusercontent.com/4452678/74687527-801d6180-5189-11ea-80c0-85b64c69e161.png)

