### PR TITLE
Replace therapeutic approach "both" with "prophylactic, symptomatic"

### DIFF
--- a/R/mod-review-section.R
+++ b/R/mod-review-section.R
@@ -134,7 +134,14 @@ mod_review_section_server <- function(input, output, session, synapse, syn,
     sub_section <- dplyr::filter(
       sub_data,
       .data$form_data_id == submission_id() & .data$step == section()
-    )
+    ) %>%
+      dplyr::mutate(
+        response = dplyr::case_when(
+          label == "What is the therapeutic approach?" & response == "both" ~
+            "prophylactic, symptomatic",
+          TRUE ~ response
+        )
+      )
     sub_section[c("label", "response")]
   })
 

--- a/R/mod-view-all-section.R
+++ b/R/mod-view-all-section.R
@@ -77,6 +77,7 @@ mod_view_all_section_server <- function(input, output, session, synapse, syn,
               "prophylactic, symptomatic",
             TRUE ~ response
           )
+        )
         output$submissions <- reactable::renderReactable({
           reactable::reactable(
             submissions,

--- a/R/mod-view-all-section.R
+++ b/R/mod-view-all-section.R
@@ -68,6 +68,15 @@ mod_view_all_section_server <- function(input, output, session, synapse, syn,
         if (is.null(submissions)) {
           stop("No submissions found with requested status(es)")
         }
+        ## Replace "both" with "prophylactic, symptomatic" in answer to question
+        ## "What is the therapeutic approach?"
+        submissions <- dplyr::mutate(
+          submissions,
+          response = dplyr::case_when(
+            label == "What is the therapeutic approach?" & response == "both" ~
+              "prophylactic, symptomatic",
+            TRUE ~ response
+          )
         output$submissions <- reactable::renderReactable({
           reactable::reactable(
             submissions,


### PR DESCRIPTION
Fixes #53. Not sure if it's better to replace this in the full dataset when it's loaded, or only in the subset of interest. My thinking was that in a given session, the user might not view the "basic data" section at all, so we don't want to do a lot of data wrangling operations that won't matter, but I'm open to other options. Thoughts @Aryllen?