### PR TITLE
fix refresh error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,8 @@ Imports:
     synapseforms,
     tibble,
     tidyr,
-    waiter
+    waiter,
+    htmlwidgets
 Remotes:
     Sage-Bionetworks/synapseforms
 RoxygenNote: 7.1.1

--- a/R/app-ui.R
+++ b/R/app-ui.R
@@ -17,6 +17,7 @@ golem_add_external_resources <- function() {
   tags$head(
     golem::activate_js(),
     golem::favicon(),
-    tags$script(src = "www/readCookie.js")
+    tags$script(src = "www/readCookie.js"),
+    tags$script(htmlwidgets::JS("setTimeout(function(){history.pushState({}, 'STOP-AD submission reviewer', window.location.pathname);},2000);"))
   )
 }

--- a/R/app-ui.R
+++ b/R/app-ui.R
@@ -14,6 +14,7 @@ golem_add_external_resources <- function() {
     "www", system.file("app/www", package = "stopadforms")
   )
 
+  #hack fix for refresh error
   tags$head(
     golem::activate_js(),
     golem::favicon(),

--- a/R/mod-main.R
+++ b/R/mod-main.R
@@ -21,6 +21,7 @@ mod_main_ui <- function(id) {
 
     # List the first level UI elements here
     navbarPage(
+      #name for refresh hack
       "STOP-AD submission reviewer",
       mod_review_section_ui(
         ns("review_section")

--- a/R/mod-panel-section.R
+++ b/R/mod-panel-section.R
@@ -77,8 +77,6 @@ mod_panel_section_server <- function(input, output, session, synapse, syn, user,
                                      submissions_table) {
   ## Load submissions and reviews
   submissions <- append_clinical_to_submission(submissions) %>%
-    #bug fix for extra whitespace
-    #suggested further upstream fix in future
     dplyr::mutate(submission = submission %>% trimws())
   reviews <- pull_reviews_table(syn, reviews_table, submissions)
 

--- a/R/mod-panel-section.R
+++ b/R/mod-panel-section.R
@@ -77,6 +77,8 @@ mod_panel_section_server <- function(input, output, session, synapse, syn, user,
                                      submissions_table) {
   ## Load submissions and reviews
   submissions <- append_clinical_to_submission(submissions) %>%
+    #bug fix for extra whitespace
+    #suggested further upstream fix in future
     dplyr::mutate(submission = submission %>% trimws())
   reviews <- pull_reviews_table(syn, reviews_table, submissions)
 


### PR DESCRIPTION
This fixes refresh error.

From @brucehoff 

"I think what’s going on here is that when I reload the page I make the Shiny app’ think it’s getting a redirect back from Synapse and it tries to get an access token with the old auth’ code.  The app’ gets a 400 response from Synapse and displays the error message.
[11:48](https://sagebionetworks.slack.com/archives/C03N8UHRACQ/p1656614923834989)
The way to test the theory is to change the app’ so that the auth’ code is not available in the URL bar for ‘replay’."

https://github.com/curso-r/auth0/issues/54#issuecomment-719111543
https://sagebionetworks.jira.com/browse/SWC-5297