### PR TITLE
attempt to pin R container

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,7 +25,7 @@ jobs:
 #          - {os: macOS-latest,   r: 'devel'}
           - {os: macOS-latest,   r: 'release'}
           - {os: ubuntu-20.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
-          - {os: ubuntu-20.04,   r: '4.2.2', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
+          - {os: ubuntu-20.04,   r: '4.2.3', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
           - {os: ubuntu-20.04,   r: '4.0.3', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
 
     env:

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -13,6 +13,7 @@ jobs:
   shinyDeploy:
     if: github.event.pull_request.merged == true
     runs-on: Ubuntu-20.04
+    container: rocker/rstudio:4.2.3
  
     steps:
  


### PR DESCRIPTION
See this ticket:

https://sagebionetworks.jira.com/browse/ALZ-151?atlOrigin=eyJpIjoiNmU3OGM1MmI4ZWQ1NDI4Y2FkMzA0NzI5YTUzMzk5MjUiLCJwIjoiaiJ9

Try to containerize the app so that we control the R version it relies on

If this works, we can pin the R version to the latest compatible version (4.2.3)

We can ensure that the test matrix is always testing that version (4.2.3)

