### PR TITLE
add linux depedency openssl11-libs

### DIFF
--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           sudo apt-get update
           # The rsconnect R package needs cUrl.  This app needs the Java JDK (runtime AND compiler).
-          sudo apt-get install -y libcurl4-openssl-dev default-jdk
+          sudo apt-get install -y libcurl4-openssl-dev default-jdk openssl11-libs
  
       - uses: actions/checkout@v2
         


### PR DESCRIPTION
See failure from latest deployment

https://github.com/Sage-Bionetworks/stopadforms/actions/runs/5084191712

Possible Bug fix:
https://stackoverflow.com/questions/42828083/error-while-loading-shared-libraries-usr-local-lib64-libssl-so-1-1

Let me know about additional ideas (nothing urgent) 