### PR TITLE
fixes for pkgdown

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -8,7 +8,8 @@ name: pkgdown
 
 jobs:
   pkgdown:
-    runs-on: macOS-latest
+    runs-on: Ubuntu-20.04
+    container: rocker/rstudio:4.1.3
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
Hi all,

The staging instance for this app seems to work:
https://sagebio.shinyapps.io/stopadforms-staging/

Please try it out!

pkgdown.yaml is outdated and failing; I made updates for it to run on Ubuntu-20.04 and rocker/rstudio:4.1.3 container

From @andrewelamb , deployments to shinyapps.io can be a bit of trial and error, so we'll encounter a bit of this.

