### PR TITLE
Add forceUpdate parameter to rsconnect::deployApp

### DIFF
--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -65,5 +65,5 @@ jobs:
           options(rsconnect.max.bundle.size=3145728000)
           rsconnect::setAccountInfo(rsConnectUser, rsConnectToken, rsConnectSecret)
           appFiles<-dir(all.files=TRUE, include.dirs=TRUE)
-          rsconnect::deployApp(appName = appName, appFiles=appFiles)
+          rsconnect::deployApp(appName = appName, appFiles=appFiles, forceUpdate = TRUE)
         shell: Rscript {0}


### PR DESCRIPTION
Update `rsconnect` command to handle missing deployment records.

Deployment error:
Error in `shouldUpdateApp()`:
! Discovered a previously deployed app named "stopadforms-staging"
(View it at <https://***.shinyapps.io/stopadforms-staging/>)
ℹ Set `forceUpdate = TRUE` to update it.
ℹ Supply a unique `appName` to deploy a new application.

From the [rsconnect docs:](https://cran.r-project.org/web/packages/rsconnect/rsconnect.pdf)
forceUpdate What should happen if there’s no deployment record for the app, but there’s an app with the same name on the server? If TRUE, will always update the previously-deployed app. If FALSE, will ask the user what to do, or fail if not in an interactive context.