### PR TITLE
Test deployment with downgraded rsconnect version

### DIFF
--- a/install-pkgs.R
+++ b/install-pkgs.R
@@ -19,7 +19,7 @@ cran <- c(
 "tidyr",
 "waiter",
 "htmlwidgets",
-"rsconnect",
+# "rsconnect", TODO remove this line if install_version solves the deployment issue
 "brio",
 "callr",
 "diffobj",
@@ -37,6 +37,10 @@ cran <- c(
 # For Ubuntu 20.04 (Focal)  it's https://packagemanager.rstudio.com/all/__linux__/focal/latest
 options(repos = c(REPO_NAME = "https://packagemanager.rstudio.com/all/__linux__/bionic/latest", getOption("repos")))
 install.packages(cran)
+
+# Downgrade rsconnect to a version that is compatible with shinyapps.io
+# https://community.rstudio.com/t/unable-to-deploy-on-shinyapp-io/170160
+remotes::install_version("rsconnect", "0.8.29")
 
 packages_installed_from_github <- c("dreamRs/shinypop", "Sage-Bionetworks/dccvalidator", "Sage-Bionetworks/synapseforms")
 remotes::install_github(packages_installed_from_github)


### PR DESCRIPTION
Trying rsconnect 0.8.29 per https://community.rstudio.com/t/unable-to-deploy-on-shinyapp-io/170160