### PR TITLE
[ALZ-179] Use CSV-based table insertion

### DIFF
--- a/R/mod-review-section.R
+++ b/R/mod-review-section.R
@@ -197,7 +197,15 @@ mod_review_section_server <- function(input, output, session, synapse, syn,
       } else {
         stop("Unable to update score: duplicate scores were found for this section from a single reviewer") # nolint
       }
-      syn$store(synapse$Table(reviews_table, new_row))
+      
+      # Create a temporary file path
+      temp_file <- tempfile(fileext = ".csv")
+      
+      # Write the data frame to the temporary CSV file
+      write.csv(new_row, temp_file, row.names = FALSE)
+      
+      syn$store(synapse$Table(reviews_table, temp_file))
+      
       shinyjs::reset("section_score")
       shinyjs::reset("section_species")
       shinyjs::reset("section_comments")


### PR DESCRIPTION
The root issue appears to be a failure to import Pandas - because Pandas can't be imported, the dictionary representing the new row can't get imported either.

I believe this has something to do with numpy / pandas and the respective 2.0 variations - i think `synapseclient` in Python depends on Pandas 2.0+, but Numpy 1.24.x... and there's an import failure.

Fixing the above would be the ideal solution - but until then, if we create a temp CSV on disk with the row to be inserted, we can pass a string filepath to it, and the synapse$Table method handles it!