### PR TITLE
[ALZ-182] Expand all rows by default in summary

### DIFF
--- a/R/mod-panel-section.R
+++ b/R/mod-panel-section.R
@@ -227,6 +227,7 @@ show_review_table <- function(input, output, reviews, submission_id) {
       groupBy = "step",
       searchable = TRUE,
       pagination = FALSE,
+      defaultExpanded = TRUE,
       columns = list(
         step = reactable::colDef(name = "Section"),
         score = reactable::colDef(name = "Gamma", aggregate = "unique"),


### PR DESCRIPTION
This uses a reacttable option to ensure all rows are expanded by default