### PR TITLE
[ALZ-94] Reorder sections in summarize tab

### DIFF
--- a/R/mod-panel-section.R
+++ b/R/mod-panel-section.R
@@ -218,7 +218,11 @@ show_review_table <- function(input, output, reviews, submission_id) {
         .data$weighted_score,
         .data$scorer,
         .data$comments
-      )
+      ) %>%
+      dplyr::mutate(
+        step = factor(.data$step, levels = reorder_steps(.data$step))
+      ) %>%
+      dplyr::arrange(step)
   })
 
   output$averaged_scores <- reactable::renderReactable({


### PR DESCRIPTION
This makes sure that sections appear in the same order as the review tab.