### PR TITLE
[ALZ-109] Expand and collapse all submissions

### DIFF
--- a/R/mod-view-all-section.R
+++ b/R/mod-view-all-section.R
@@ -37,10 +37,18 @@ mod_view_all_section_ui <- function(id) {
         with_busy_indicator_ui(
           actionButton(
             ns("select_status"),
-            "Submit Selection"
+            "Submit Selection",
+            width = "175px"
           )
         )
       )
+    ),
+    # Add buttons to expand/collapse all
+    fluidRow(
+      column(1, offset = 1,
+             actionButton(ns("expand_all"), "Expand All")),
+      column(1,
+             actionButton(ns("collapse_all"), "Collapse All"))
     ),
     fluidRow(
       column(
@@ -56,6 +64,15 @@ mod_view_all_section_ui <- function(id) {
 #' @keywords internal
 mod_view_all_section_server <- function(input, output, session, synapse, syn,
                                         group, lookup_table, sub_metadata) {
+  
+  observeEvent(input$expand_all, {
+    reactable::updateReactable("submissions", expanded = TRUE, session = getDefaultReactiveDomain())
+  })
+  
+  observeEvent(input$collapse_all, {
+    reactable::updateReactable("submissions", expanded = FALSE, session = getDefaultReactiveDomain())
+  })
+  
   observeEvent(input$select_status, {
     with_busy_indicator_server("select_status", {
       submissions <- get_submissions(

--- a/R/mod-view-all-section.R
+++ b/R/mod-view-all-section.R
@@ -38,11 +38,12 @@ mod_view_all_section_ui <- function(id) {
           actionButton(
             ns("select_status"),
             "Submit Selection",
-            width = "175px"
+            width = "230px"
           )
         )
       )
     ),
+    br(),
     # Add buttons to expand/collapse all
     fluidRow(
       column(1, offset = 1,


### PR DESCRIPTION
This PR adds expand and collapse all buttons on the view all submissions tab
<img width="1053" alt="Screenshot 2024-08-27 at 9 21 26 AM" src="https://github.com/user-attachments/assets/65ecb2c3-ecca-4e61-9e04-244763c53744">
