### PR TITLE
[ALZ-245] Append step number always, even when one exp

### DIFF
--- a/R/data-gather-clean.R
+++ b/R/data-gather-clean.R
@@ -284,7 +284,7 @@ append_exp_nums <- function(data) {
     data,
     step = dplyr::case_when(
       !is.na(exp_num) ~ as.character(glue::glue("{step} [{exp_num}]")),
-      TRUE ~ step
+      TRUE ~ as.character(glue::glue("{step} [1]"))
     )
   )
 }


### PR DESCRIPTION
This PR will include [1] as a suffix for the step, even when there's only a single experiment for that step.